### PR TITLE
change rss to fixed path due to link error after migration to Firebase

### DIFF
--- a/serambi/feeds
+++ b/serambi/feeds
@@ -120,7 +120,7 @@ name = Herpiko Dwi Aguno
 [http://aksi.mdamt.net/feeds/posts/default]
 name = MDAMT
 
-[https://linhub.io/rss]
+[https://linhub.io/rss.xml]
 name = Ngalim Siregar
 
 ## Legacy


### PR DESCRIPTION
Merubah path rss ke bentuk `fixed` karena terjadi galat setelah migrasi ke Firebase